### PR TITLE
fixes problem with calling jMoment.utc without locale

### DIFF
--- a/jalali-moment.js
+++ b/jalali-moment.js
@@ -136,6 +136,7 @@ function isArray(input) {
  * @example toJalaliFormat("YYYY/MMM/DD") => "jYYYY/jMMM/jDD"
  **/
 function toJalaliFormat(format) {
+    if (typeof format === "function")
     for (var i = 0; i < format.length; i++) {
         if(!i || (format[i-1] !== "j" && format[i-1] !== format[i])) {
             if (format[i] === "Y" || format[i] === "M" || format[i] === "D" || format[i] === "g") {
@@ -569,7 +570,7 @@ function jWeekOfYear(mom, firstDayOfWeek, firstDayOfWeekOfYear) {
 
 function makeMoment(input, format, lang, strict, utc) {
     if (typeof lang === "boolean") {
-        utc = strict;
+        utc = utc || strict;
         strict = lang;
         lang = undefined;
     }

--- a/jalali-moment.js
+++ b/jalali-moment.js
@@ -171,13 +171,13 @@ function normalizeUnits(units, momentObj) {
     if (isJalali(momentObj)) {
         units = toJalaliUnit(units);
     }
-    if (units) {
+     if (units) {
         var lowered = units.toLowerCase();
-        units = unitAliases[lowered] || lowered;
+        if (lowered.startsWith('j')) units = unitAliases[lowered] || lowered;
+        // TODO : add unit test
+        if (units === "jday") units = "day";
+        else if (units === "jd") units = "d";
     }
-    // TODO : add unit test
-    if (units === "jday") units = "day";
-    else if (units === "jd") units = "d";
     return units;
 }
 

--- a/jalali-moment.js
+++ b/jalali-moment.js
@@ -136,7 +136,6 @@ function isArray(input) {
  * @example toJalaliFormat("YYYY/MMM/DD") => "jYYYY/jMMM/jDD"
  **/
 function toJalaliFormat(format) {
-    if (typeof format === "function")
     for (var i = 0; i < format.length; i++) {
         if(!i || (format[i-1] !== "j" && format[i-1] !== format[i])) {
             if (format[i] === "Y" || format[i] === "M" || format[i] === "D" || format[i] === "g") {


### PR DESCRIPTION
fixes issue #66 

Another solution is to change moment.utc as fallow:
```javascript
jMoment.utc = function (input, format, lang, strict) {
    if (typeof lang === "boolean") {
        strict = lang;
        lang = undefined;
    }
    return makeMoment(input, format, lang, strict, true);
};
```
but I think the provided solution is more general.