### PR TITLE
Update jalali-moment.d.ts

### DIFF
--- a/jalali-moment.d.ts
+++ b/jalali-moment.d.ts
@@ -570,7 +570,7 @@ declare namespace moment {
 
     toArray(): number[];
     toDate(): Date;
-    toISOString(): string;
+    toISOString(keepTimeOffset?: boolean): string;
     inspect(): string;
     toJSON(): string;
     unix(): number;

--- a/jalali-moment.d.ts
+++ b/jalali-moment.d.ts
@@ -198,7 +198,7 @@ declare namespace moment {
     locale(locale: LocaleSpecifier): Duration;
     localeData(): Locale;
 
-    toISOString(): string;
+    toISOString(keepTimeOffset?: boolean): string;
     toJSON(): string;
 
     /**

--- a/test.js
+++ b/test.js
@@ -1160,6 +1160,25 @@ describe("moment", function() {
             jalaliMoment("2019-02-23").format("YYYY-MM-DD").should.be.equal("1397-12-04");
         });
     });
+
+    describe("jalaliMoment toISOString", function () {
+        jalaliMoment.locale("en");
+        it("toISOString(false) with 00:00 time and GMT+ timezone should decrease day", function () {
+            const date = jalaliMoment("2020-11-23T00:00:00.000+03:30");
+            const isoString = date.toISOString();
+            const dateWithoutTimezone = jalaliMoment(isoString.split('T')[0]);
+            date.date().should.be.equal(dateWithoutTimezone.date() + 1);
+            date.format("YYYY-MM-DD").should.not.equal(dateWithoutTimezone.format("YYYY-MM-DD"));
+        });
+        
+        it("toISOString(true) with 00:00 time and GMT+ timezone should preserve date", function () {
+            const date = jalaliMoment("2020-11-23T00:00:00.000+03:30");
+            const isoString = date.toISOString(true);
+            const dateWithoutTimezone = jalaliMoment(isoString.split('T')[0]);
+            date.format("YYYY-MM-DD").should.be.equal(dateWithoutTimezone.format("YYYY-MM-DD"));
+        });
+    });
+
     describe("compare jalaliMoment and moment", function () {
         it("utc should be the same", function () {
             const a = jalaliMoment.utc("09:30", "HH:mm");


### PR DESCRIPTION
Added keepTimeOffset to toISOString function.
https://momentjs.com/docs/#/displaying/as-iso-string/
--
there is a problem with `moment().toISOString();` and it has been fixed in original `moment` library ([link](https://momentjs.com/docs/#/displaying/as-iso-string/)).
```
const n = moment.utc(new Date('"2020-11-23"'))
```
It will return:
```
Mon Nov 23 2020 03:30:00 GMT+0330 (Iran Standard Time)
```
Now if I call toISOString() on it, the date suddenly becomes 22th:
```
n.toISOString()
```
the above will return the 22th instead of 23th:
```
"2020-11-22T20:30:00.000Z"
```
fix:
```
>> n.toISOString(true)
"2020-11-23T00:00:00.000+03:30"
```
