### PR TITLE
🐞 FIX: endOf skips a day if the day of daylight saving time is chosen in leap year

### DIFF
--- a/jalali-moment.js
+++ b/jalali-moment.js
@@ -944,7 +944,7 @@ jMoment.fn.endOf = function (units) {
     if (units === undefined || units === "milisecond") {
         return this;
     }
-    return this.startOf(units).add(1, units).subtract(1, "ms");
+    return this.add(1, units).startOf(units).subtract(1, "ms");
 };
 
 jMoment.fn.isSame = function (other, units) {


### PR DESCRIPTION
For example following command results in wrong value:
```javascript
moment("2021-03-22T01:01:30.452+04:30").endOf("day").format("jYYYY/jMM/jDD HH:mm")
```

Correct result: **1400/01/02 23:59**
Current result (wrong): **1400/01/03 00:59**